### PR TITLE
fix: update GitHub link in About page

### DIFF
--- a/display.py
+++ b/display.py
@@ -279,7 +279,7 @@ class DisplayController:
         elif current_page == PAGE_SETTINGS_ABOUT:
             self._write('fill 0,400,320,60,' + str(BACKGROUND_GRAY))
             self._write('xstr 0,400,320,30,1,65535,' + str(BACKGROUND_GRAY) + ',1,1,1,"OpenNept4une"')
-            self._write('xstr 0,430,320,30,2,GRAY,' + str(BACKGROUND_GRAY) + ',1,1,1,"github.com/halfmanbear/OpenNept4une"')
+            self._write('xstr 0,430,320,30,2,GRAY,' + str(BACKGROUND_GRAY) + ',1,1,1,"github.com/OpenNeptune3D"')
         elif current_page == PAGE_CONFIRM_PRINT:
             self._loop.create_task(self.set_data_prepare_screen(self.current_filename))
         elif current_page == PAGE_PRINTING:


### PR DESCRIPTION
Setting up the new organization as the URL at the footer of the About page.

I didn't place the full repo URL, as the result was this:
<img src="https://github.com/OpenNeptune3D/display_connector/assets/11593618/eba7e69c-d746-4afb-936e-33c587d3f0a9" height="500" />

Considering the organization is expected to have more repos, pointing to the org seems reasonable 😄 

The page would look like this:
<img src="https://github.com/OpenNeptune3D/display_connector/assets/11593618/d1f6fde1-0381-4776-87d4-d6cfa8d95c47" height="500" />


Targetting `dev`