### PR TITLE
fix: bump actions' versions to latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3.11
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: "3.11"
     - name: Install dependencies
@@ -29,9 +29,9 @@ jobs:
   bandit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3.11
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: "3.11"
     - name: Install dependencies
@@ -52,9 +52,9 @@ jobs:
           - "3.11"
           - "3.12"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python_version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python_version }}
     - name: Install dependencies


### PR DESCRIPTION
Aims to fix deprecation warnings when running Actions. A quite common thing to maintain over the DevOps-side of things 😄 

<img width="1339" alt="Screenshot 2024-02-17 at 08 43 53" src="https://github.com/OpenNeptune3D/display_connector/assets/11593618/d084080f-dac6-4104-bb23-bdc2d78157b7">
