### PR TITLE
Dev to Main

### DIFF
--- a/display.py
+++ b/display.py
@@ -1463,13 +1463,13 @@ class DisplayController:
         if "config" in new_data:
             if "stepper_x" in new_data["config"]:
                 if "position_max" in new_data["config"]["stepper_x"]:
-                    max_x = int(new_data["config"]["stepper_x"]["position_max"])
+                    max_x = int(float(new_data["config"]["stepper_x"]["position_max"])) #added conversion from float numbers, stripping decimal part
             if "stepper_y" in new_data["config"]:
-                if "position_max" in new_data["config"]["stepper_y"]:
-                    max_y = int(new_data["config"]["stepper_y"]["position_max"])
+                if "position_max" in new_data["config"]["stepper_x"]:
+                    max_y = int(float(new_data["config"]["stepper_y"]["position_max"])) #added conversion from float numbers, stripping decimal part
             if "stepper_z" in new_data["config"]:
-                if "position_max" in new_data["config"]["stepper_z"]:
-                    max_z = int(new_data["config"]["stepper_z"]["position_max"])
+                if "position_max" in new_data["config"]["stepper_x"]:
+                    max_z = int(float(new_data["config"]["stepper_z"]["position_max"])) #added conversion from float numbers, stripping decimal part
 
             if max_x > 0 and max_y > 0 and max_z > 0:
                 logger.info(f"Machine Size: {max_x}x{max_y}x{max_z}")


### PR DESCRIPTION
Fixed display.py errors (and display freezing/restarting) when any stepper "position_max" is written as float number for maximizing plate size in printer.cfg