### PR TITLE
Fix temperature display freezing due to broken encoding override

### DIFF
--- a/src/communicator.py
+++ b/src/communicator.py
@@ -32,8 +32,7 @@ class DisplayCommunicator:
         self._write_lock = asyncio.Lock()
 
         # Ensure TJCClient is properly instantiated
-        self.display = TJCClient(port, baudrate, event_handler)
-        self.display.encoding = "utf-8"
+        self.display = TJCClient(port, baudrate, event_handler, encoding="utf-8")
 
     async def connect(self):
         try:


### PR DESCRIPTION
TJCClient inherits Nextion.__init__ directly, which stores the encoding privately as self._encoding at construction time (default "ascii"). Setting self.display.encoding after construction never touched that attribute, so it was a no-op since the very first commit.

Every write containing a non-ASCII character (e.g. format_temp's "°C") raised UnicodeEncodeError, which was silently swallowed by the generic except clause in _execute_command - so temperature values never reached the display and stayed frozen at whatever was compiled into the .tft (200°C hotend / 100°C bed).

Fixes [OpenNeptune3D/display_firmware#8](https://github.com/OpenNeptune3D/display_firmware/issues/8)