### PR TITLE
Fix/rapid scan display freeze

### DIFF
--- a/display.py
+++ b/display.py
@@ -2163,7 +2163,14 @@ class DisplayController:
                     )
                 )
 
-        elif response.startswith("// Mesh Bed Leveling Complete") or "Collecting samples along the scanning path completed" in response:
+        elif (
+            response.startswith("// Mesh Bed Leveling Complete")
+            or "Collecting samples along the scanning path completed" in response
+            # cartographer-klipper's scanner.py (scan mode) reports its own
+            # completion this way instead of either message above - without
+            # this, _bed_leveling_complete never clears for that probe/plugin
+            or "Mesh calibration complete" in response
+        ):
             # If rapid scan mode was active, show completion
             # Draw boxes if we received probe counts (some probes send both rapid scan AND counts)
             if self._rapid_scan_mode:

--- a/display.py
+++ b/display.py
@@ -2111,7 +2111,14 @@ class DisplayController:
             self._rapid_scan_mode = True
             self.bed_leveling_probed_count = 0
             self.bed_leveling_last_position = None
-            self._bed_leveling_complete = False
+            # Mark complete up front rather than waiting for the explicit
+            # completion message below - rapid-scan probes don't reliably send
+            # "// Mesh Bed Leveling Complete" or the scanning-path completion
+            # text, which left this flag stuck False and the navigation guard
+            # in _navigate_to_page() blocking the screen on this page forever
+            # (see #62). The completion branch still runs normally and updates
+            # the visualization if the message does arrive.
+            self._bed_leveling_complete = True
             # Reset leveling_mode for KAMP during printing
             if self.current_state in ("printing", "paused"):
                 self.leveling_mode = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import os
+
+# display.py sets up a FileHandler pointed at ~/printer_data/logs at import
+# time, which is only guaranteed to exist on a real printer install. Create
+# it here so tests can import display.py in CI and other dev environments.
+os.makedirs(os.path.expanduser("~/printer_data/logs"), exist_ok=True)

--- a/tests/display_test.py
+++ b/tests/display_test.py
@@ -76,3 +76,36 @@ async def test_pre_fix_behavior_would_freeze_navigation(controller):
     await controller._navigate_to_page(PAGE_PRINTING_COMPLETE)
 
     assert controller.history[-1] == PAGE_PRINTING_KAMP
+
+
+@pytest.mark.asyncio
+async def test_cartographer_klipper_scan_mode_completion_marks_bed_leveling_complete(controller):
+    # cartographer-klipper's scanner.py (the original Cartographer plugin, in
+    # scan mode) reports mesh completion with this text instead of either
+    # message this module otherwise checks for - without recognizing it,
+    # _bed_leveling_complete is left stuck False for that plugin. The flag is
+    # only ever set from this branch while parked on printing_kamp.
+    controller.history = [PAGE_PRINTING_KAMP]
+    controller._bed_leveling_complete = False
+
+    await controller.handle_gcode_response("Mesh calibration complete")
+
+    assert controller._bed_leveling_complete is True
+
+
+@pytest.mark.asyncio
+async def test_cartographer_klipper_scan_completion_clears_flag_set_by_kamp(controller):
+    # End-to-end reproduction of the freeze actually seen on hardware: KAMP's
+    # adaptive-meshing macro parks the screen on printing_kamp and marks
+    # leveling incomplete, then cartographer-klipper's scan-mode completion
+    # message must be recognized to clear it again.
+    await controller.handle_gcode_response(
+        "// Adapted mesh bounds: (80.0417, 80.0), (154.958, 155.0)."
+    )
+    await asyncio.sleep(0)
+    controller.history = [PAGE_PRINTING_KAMP]
+    assert controller._bed_leveling_complete is False
+
+    await controller.handle_gcode_response("Mesh calibration complete")
+
+    assert controller._bed_leveling_complete is True

--- a/tests/display_test.py
+++ b/tests/display_test.py
@@ -1,0 +1,78 @@
+import asyncio
+import logging
+from unittest.mock import AsyncMock
+
+import pytest
+import pytest_asyncio
+
+import display as display_module
+from src.config import ConfigHandler
+from src.mapping import PAGE_PRINTING_COMPLETE, PAGE_PRINTING_KAMP, filename_regex_wrapper
+from src.neptune4 import MODEL_N4_PRO
+
+logger = logging.getLogger(__name__)
+
+
+@pytest_asyncio.fixture
+async def controller(tmp_path):
+    # A fresh ConfigHandler writes a default clean_filename_regex, and
+    # DisplayController.__init__ -> _handle_config() compiles it straight into
+    # the module-level filename_regex_wrapper in src/mapping.py. Save/restore
+    # it so this doesn't leak into other test modules in the same session.
+    original_filename_regex = dict(filename_regex_wrapper)
+    try:
+        config = ConfigHandler(str(tmp_path / "test_config.ini"), logger)
+        if "general" not in config:
+            config.add_section("general")
+        config.set("general", "printer_model", MODEL_N4_PRO)
+        config.write_changes()
+
+        loop = asyncio.get_running_loop()
+        controller = display_module.DisplayController(config, loop)
+        # No real display attached in tests - avoid touching serial I/O.
+        controller.display.write = AsyncMock()
+        yield controller
+    finally:
+        filename_regex_wrapper.clear()
+        filename_regex_wrapper.update(original_filename_regex)
+
+
+@pytest.mark.asyncio
+async def test_rapid_scan_marks_bed_leveling_complete(controller):
+    # Cartographer/Eddy/Beacon probes announce their scan with this message and
+    # never reliably send the "// Mesh Bed Leveling Complete" (or KAMP
+    # scanning-path) text this module otherwise waits for to clear the flag.
+    await controller.handle_gcode_response("Beginning rapid surface scan")
+    await asyncio.sleep(0)  # let the create_task()-scheduled navigation run
+
+    assert controller._rapid_scan_mode is True
+    assert controller._bed_leveling_complete is True
+
+
+@pytest.mark.asyncio
+async def test_rapid_scan_does_not_freeze_navigation_away_from_kamp_page(controller):
+    # Reproduces https://github.com/OpenNeptune3D/display_connector/issues/62:
+    # a rapid-scan probe starts a mesh, the screen parks on printing_kamp, and
+    # the print later finishes ("Status Update: complete" in the issue's log)
+    # while the display is still trying to navigate off that page.
+    await controller.handle_gcode_response("Beginning rapid surface scan")
+    await asyncio.sleep(0)
+    controller.history = [PAGE_PRINTING_KAMP]
+
+    await controller._navigate_to_page(PAGE_PRINTING_COMPLETE)
+
+    assert controller.history[-1] == PAGE_PRINTING_COMPLETE
+
+
+@pytest.mark.asyncio
+async def test_pre_fix_behavior_would_freeze_navigation(controller):
+    # Documents the bug this fix addresses: with the flag left False (the
+    # pre-fix behavior when no completion message ever arrives), the guard in
+    # _navigate_to_page() blocks leaving printing_kamp indefinitely.
+    controller._rapid_scan_mode = True
+    controller._bed_leveling_complete = False
+    controller.history = [PAGE_PRINTING_KAMP]
+
+    await controller._navigate_to_page(PAGE_PRINTING_COMPLETE)
+
+    assert controller.history[-1] == PAGE_PRINTING_KAMP


### PR DESCRIPTION
## Summary

`display_connector` can freeze on the "Creating Bed Mesh" (`printing_kamp`) screen forever during a Cartographer/Eddy/Beacon bed mesh scan, even though the mesh and print both finish successfully underneath. The navigation guard in `_navigate_to_page()` blocks leaving that screen until `_bed_leveling_complete` is `True`, and that flag only ever flips on an explicit completion message — two probe/plugin variants never send one it recognizes.

Fixes two distinct cases of this:

1. **Newer `cartographer3d-plugin`** (fixes #62): announces its scan with `"Beginning rapid surface scan"` / `"Touch home at"`, but its actual completion text doesn't reliably match either string this module waits for (`"// Mesh Bed Leveling Complete"` or `"Collecting samples along the scanning path completed"`). Fix: mark `_bed_leveling_complete = True` as soon as rapid-scan mode is detected, instead of waiting on a completion message that may never arrive. The existing completion branch still runs normally and updates the visualization if the message does show up.

2. **Older `cartographer-klipper` plugin, scan mode**: reports completion with different text entirely — `self.gcode.respond_info("Mesh calibration complete")` (confirmed from source: [`scanner.py:3798`](https://github.com/Cartographer3D/cartographer-klipper/blob/master/scanner.py)) — which isn't matched by either existing string. Fix: also recognize `"Mesh calibration complete"` as a completion signal.

Case 2 is confirmed via `klippy.log` and live hardware testing: the mesh and print were always completing fine (`Mesh calibration complete` → `save_config` → print continuing normally) — this was purely a display-side bug, never a Klipper-side failure. Case 1 is not something my hardware exercises (my printer runs the older plugin, so that code path never triggers for me) — it's fixed based on the report and logs in #62, and covered by unit tests, but I haven't verified it live myself.

## Test plan

- [x] Added regression tests in `tests/display_test.py` covering both cases (flag transitions and end-to-end navigation-guard behavior), plus a test documenting the pre-fix freeze
- [x] Confirmed each new test fails without its corresponding fix and passes with it
- [x] Full test suite passes (`pytest tests/`)
- [x] `ruff check` and `bandit -r display.py src/` clean
- [x] Case 2 (`cartographer-klipper`, scan mode) deployed and confirmed working live on hardware — display no longer freezes on mesh completion
- [ ] Case 1 (`cartographer3d-plugin` rapid-scan) not verified on real hardware — @oley83 (or anyone else on that plugin), if you can test this branch that'd help confirm it
