### PR TITLE
Fix TFT UTF-8 encoding for Unicode display text

### DIFF
--- a/src/communicator.py
+++ b/src/communicator.py
@@ -33,7 +33,7 @@ class DisplayCommunicator:
 
         # Ensure TJCClient is properly instantiated
         self.display = TJCClient(port, baudrate, event_handler)
-        self.display.encoding = "utf-8"
+        self.display._encoding = "utf-8"
 
     async def connect(self):
         try:


### PR DESCRIPTION
Problem

The TFT display connector forces the nextion client encoding using:

self.display.encoding = "utf-8"

With nextion version 3.0.0, the client stores the encoding internally as _encoding. The public encoding attribute is not used by the command implementation.

As a result, commands containing Unicode characters, such as the degree symbol (°) in temperature values, can still be encoded using the default ASCII encoding and cause encoding errors.

Cause

The nextion client encodes outgoing commands in _command() using:

command.encode(self._encoding)

Therefore, setting encoding does not change the encoding actually used by the client.

Fix

Set the internal encoding attribute used by the installed nextion client:

- self.display.encoding = "utf-8"
+ self.display._encoding = "utf-8"

This ensures that outgoing display commands are encoded as UTF-8 and allows Unicode characters such as ° to be transmitted correctly.

Testing

Tested on an Elegoo Neptune 4 Pro running the OpenNept4une display connector.

The TFT display was tested with temperature values containing the degree symbol (°C).

After the change:

The display service starts normally.
Temperature values are displayed correctly.
The °C symbol is displayed correctly.
No ASCII/Unicode encoding error is reported by the display service.

The change was also verified against nextion version 3.0.0, where _command() explicitly uses self._encoding for command encoding.

Hardware
Elegoo Neptune 4 Pro
ZNP K1 V1.1 motherboard
OpenNept4une touchscreen display
TFT firmware: 1.2.14 (reported by the display)
OpenNeptune display_connector
Python 3.13
nextion 3.0.0
Scope

This PR only changes the encoding attribute used by DisplayCommunicator.

No other functionality is modified.