### PR TITLE
Fix TFT shutdown command transmission

### DIFF
--- a/src/elegoo_display.py
+++ b/src/elegoo_display.py
@@ -800,9 +800,11 @@ class ElegooDisplayCommunicator(DisplayCommunicator):
     async def show_shutdown_screens(self):
         await self.show_initial_shutdown_screen()
         # Need to use this method here, because once we send the delay, the display won't respond anymore
-        self.display.write_command("delay=8000")
-        self.display.write_command("cls BLACK")
-        self.display.write_command(
-            'xstr 24,220,224,20,1,54150,0,1,1,1,"It\'s now safe to turn off"'
+        self.display._write_command_raw(b"delay=8000\xff\xff\xff")
+        self.display._write_command_raw(b"cls BLACK\xff\xff\xff")
+        self.display._write_command_raw(
+            b'xstr 24,220,224,20,1,54150,0,1,1,1,"It\'s now safe to turn off"\xff\xff\xff'
         )
-        self.display.write_command('xstr 24,240,224,20,1,54150,0,1,1,1,"your printer."')
+        self.display._write_command_raw(
+            b'xstr 24,240,224,20,1,54150,0,1,1,1,"your printer."\xff\xff\xff'
+        )


### PR DESCRIPTION
## Problem

The TFT shutdown sequence can fail because the display stops responding after the `delay=8000` command.

The existing implementation uses the regular `write_command()` mechanism, which expects the normal command/response handling. This is not suitable for the shutdown sequence because the TFT becomes unresponsive after the delay command.

## Cause

The shutdown commands were sent through the regular command interface:

* `delay=8000`
* `cls BLACK`
* the two final `xstr` messages

This can cause the communication layer to wait for a response that will not be received.

## Fix

Send the shutdown commands directly using the Nextion/TJC client's `_write_command_raw()` method.

Each raw command explicitly includes the required `FF FF FF` command terminator.

This allows the commands to be transmitted directly without waiting for a display response.

## Changes

* Send `delay=8000` as a raw command.
* Send `cls BLACK` as a raw command.
* Send both final shutdown messages as raw commands.
* Explicitly append `FF FF FF` to each command.

## Testing

Tested on an Elegoo Neptune 4 Pro with the OpenNept4une TouchScreen Display Service.

The shutdown sequence was tested from the TFT and the display correctly reaches the final screen:

"It's now safe to turn off"
"your printer."

The TFT no longer depends on a response from the display after `delay=8000`.

## Hardware

* Printer: Elegoo Neptune 4 Pro
* Mainboard: ZNP K1 V1.1
* TFT firmware: 1.2.14 (reported by the display)
* TFT: Elegoo Neptune 4 Pro touchscreen
* Display connector: OpenNeptune3D/display_connector
* Nextion Python library: 3.0.0
