### PR TITLE
Pass encoding to TJCClient constructor instead of setting attribute

### DIFF
--- a/src/communicator.py
+++ b/src/communicator.py
@@ -36,8 +36,7 @@ class DisplayCommunicator:
         self._nav_lock = asyncio.Lock()
 
         # Ensure TJCClient is properly instantiated
-        self.display = TJCClient(port, baudrate, event_handler)
-        self.display.encoding = "utf-8"
+        self.display = TJCClient(port, baudrate, event_handler, encoding="utf-8")
 
     async def connect(self):
         try:


### PR DESCRIPTION
## Problem

`src/communicator.py` sets `self.display.encoding = "utf-8"` after constructing `TJCClient`. This relied on a public attribute of the `nextion` library. In `nextion` 3.0.0 the attribute was renamed to `self._encoding`, so the assignment now creates an unused attribute and every command is encoded with the default `"ascii"`. Any string containing `°` (all temperature fields) fails with:

WARNING - Unexpected error writing to display: 'ascii' codec can't encode character '\xb0'


and temperature updates on the touchscreen stop — exactly the symptom in #66.

`requirements.txt` does not pin `nextion`, so this affects every fresh install / re-created venv since 3.0.0 was published. Existing installs keep their old venv and don't see it, which is why it may not reproduce for you.

## Fix

Pass `encoding="utf-8"` to the `TJCClient` constructor instead of setting the attribute afterwards. The `encoding` constructor parameter exists in both `nextion` 2.0.0 and 3.0.0, so this works on either version and removes the dependency on an internal attribute name.

Fixes #66 (the workaround proposed there strips `°` from the output; this addresses the actual cause and keeps the symbol).

## Tested

Elegoo Neptune 4, display firmware 1.2.14, Debian 12 / Python 3.11, clean venv:
- `nextion==3.0.0` before the patch: warnings above, temperatures frozen on screen
- `nextion==3.0.0` with the patch: clean log, temperatures with `°` update normally, navigated through menus without issues
- `nextion==2.0.0` with the patch: same, no regression